### PR TITLE
Update Invoke-SlowShareEnum.ps1

### DIFF
--- a/Invoke-SlowShareEnum.ps1
+++ b/Invoke-SlowShareEnum.ps1
@@ -96,7 +96,7 @@ function Invoke-SlowShareEnum {
                 $done.cnt++
                 $newShares = [System.Collections.ArrayList]@()
                 if (Wait-Job -Id $jobs[0].Job -Timeout $timeoutseconds) {
-                    $newShares = [System.Collections.ArrayList] $(Receive-Job -Id $jobs[0].Job)
+                    [System.Collections.ArrayList]$newShares = @(Receive-Job -Id $jobs[0].Job)
                     if ($null -ne $newShares) { $shares.AddRange($newShares) }
                     log "Found $($newShares.Count) shares on $($jobs[0].Computer) ($($done.cnt)/$($comps.Length) done)"
                 } else {


### PR DESCRIPTION
fixed the Cannot convert the "some String" value of type "System.String" to type "System.Collections.ArrayList."

This error happened when enumerating certain shares. I could not pin point the exact cause as when I compared shares that were enumerated vs shares that errored out there did not seem to be any syntax difference.